### PR TITLE
Send raw data through the stream

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ type StreamOption = {
      * 
      * By default all the data are sent with an id.
      */
-    rowData?: false
+    rawData?: false
 } | {
     /**
      * The format of the data sent through the stream.
@@ -49,7 +49,7 @@ type StreamOption = {
      * 
      * By default all the data are sent with an id.
      */
-    rowData: true
+    rawData: true
 }
 
 const encoder = new TextEncoder()
@@ -77,7 +77,7 @@ export class Stream<Data extends string | number | boolean | object> {
 
     private _retry?: number
     private _event?: string
-    private _rowData?: boolean
+    private _rawData?: boolean
     private label: string = ''
     private labelUint8Array = new Uint8Array()
 
@@ -120,13 +120,13 @@ export class Stream<Data extends string | number | boolean | object> {
         callback?: ((stream: Stream<Data>) => void) | MaybePromise<Streamable>,
         streamOption: StreamOption = {}
     ) {
-        if (!streamOption.rowData && streamOption.retry) 
+        if (!streamOption.rawData && streamOption.retry) 
             this._retry = streamOption.retry
-        if (!streamOption.rowData && streamOption.event) 
+        if (!streamOption.rawData && streamOption.event) 
             this._event = streamOption.event
-        if (streamOption.rowData) 
-            this._rowData = streamOption.rowData
-        if (!streamOption.rowData && (streamOption.retry || streamOption.event)) 
+        if (streamOption.rawData) 
+            this._rawData = streamOption.rawData
+        if (!streamOption.rawData && (streamOption.retry || streamOption.event)) 
             this.composeLabel()
 
         switch (typeof callback) {
@@ -199,7 +199,7 @@ export class Stream<Data extends string | number | boolean | object> {
                     ? Stream.concatUintArray(this.labelUint8Array, data)
                     : data
             )
-        } else if (this._rowData) {
+        } else if (this._rawData) {
             this.controller.enqueue(
                 encoder.encode(typeof data === 'object' ? JSON.stringify(data) : data.toString())
             )

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ type Streamable =
     | Response
     | null
 
-interface StreamOption {
+type StreamOption = {
     /**
      * A string identifying the type of event described.
      * 
@@ -31,6 +31,25 @@ interface StreamOption {
      * attempting to reconnect.
      */
     retry?: number
+    /**
+     * The format of the data sent throw the stream.
+     * 
+     * If set to true, the data will be directly sent without
+     * any transformation.
+     * 
+     * By default all the data are sent with an id.
+     */
+    rowData?: false
+} | {
+    /**
+     * The format of the data sent throw the stream.
+     * 
+     * If set to true, the data will be directly sent without
+     * any transformation.
+     * 
+     * By default all the data are sent with an id.
+     */
+    rowData: true
 }
 
 const encoder = new TextEncoder()
@@ -58,6 +77,7 @@ export class Stream<Data extends string | number | boolean | object> {
 
     private _retry?: number
     private _event?: string
+    private _rowData?: boolean
     private label: string = ''
     private labelUint8Array = new Uint8Array()
 
@@ -98,11 +118,16 @@ export class Stream<Data extends string | number | boolean | object> {
 
     constructor(
         callback?: ((stream: Stream<Data>) => void) | MaybePromise<Streamable>,
-        { retry, event }: StreamOption = {}
+        streamOption: StreamOption = {}
     ) {
-        if (retry) this._retry = retry
-        if (event) this._event = event
-        if (retry || event) this.composeLabel()
+        if (!streamOption.rowData && streamOption.retry) 
+            this._retry = streamOption.retry
+        if (!streamOption.rowData && streamOption.event) 
+            this._event = streamOption.event
+        if (streamOption.rowData) 
+            this._rowData = streamOption.rowData
+        if (!streamOption.rowData && (streamOption.retry || streamOption.event)) 
+            this.composeLabel()
 
         switch (typeof callback) {
             case 'function':
@@ -173,6 +198,10 @@ export class Stream<Data extends string | number | boolean | object> {
                 this.label
                     ? Stream.concatUintArray(this.labelUint8Array, data)
                     : data
+            )
+        } else if (this._rowData) {
+            this.controller.enqueue(
+                encoder.encode(typeof data === 'object' ? JSON.stringify(data) : data.toString())
             )
         } else
             this.controller.enqueue(

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ type StreamOption = {
      */
     retry?: number
     /**
-     * The format of the data sent throw the stream.
+     * The format of the data sent through the stream.
      * 
      * If set to true, the data will be directly sent without
      * any transformation.
@@ -42,7 +42,7 @@ type StreamOption = {
     rowData?: false
 } | {
     /**
-     * The format of the data sent throw the stream.
+     * The format of the data sent through the stream.
      * 
      * If set to true, the data will be directly sent without
      * any transformation.


### PR DESCRIPTION
Add the ability to send row data directly thought the stream (without any formatting). It can be useful when using the stream outside of a web browser or to set our own structure for the data.