### PR TITLE
🔧fix: exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@elysiajs/stream",
   "version": "1.0.3",
+  "type": "module",
   "author": {
     "name": "saltyAom",
     "url": "https://github.com/SaltyAom",
@@ -27,9 +28,9 @@
     "elysia": ">= 1.0.2"
   },
   "exports": {
+    "node": "./dist/index.js",
     "require": "./dist/cjs/index.js",
     "import": "./dist/index.js",
-    "node": "./dist/index.js",
     "default": "./dist/index.js"
   },
   "bugs": "https://github.com/elysiajs/elysia-static/issues",
@@ -43,7 +44,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "bun run --watch example/index.tsx",
-    "test": "bun test",
+    "test": "bun test && npm run test:node",
+    "test:node": "npm install --prefix ./test/node/cjs/ && npm install --prefix ./test/node/esm/ && node ./test/node/cjs/index.js && node ./test/node/esm/index.js",
     "build": "rimraf dist && tsc --project tsconfig.esm.json && tsc --project tsconfig.cjs.json",
     "release": "npm run build && npm run test && npm publish --access public"
   },

--- a/test/node/.gitignore
+++ b/test/node/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/test/node/cjs/index.js
+++ b/test/node/cjs/index.js
@@ -1,0 +1,13 @@
+// if ("Bun" in globalThis) {
+//   throw new Error("❌ Use Node.js to run this test!");
+// }
+
+// const { Stream } = require("@elysiajs/stream");
+
+// if (typeof Stream !== "function" && Stream["name"] === "Stream") {
+//   throw new Error("❌ CommonJS Node.js failed");
+// }
+
+// console.log("✅ CommonJS Node.js works!");
+
+console.log("⏩ CommonJS Node.js unsupported");

--- a/test/node/cjs/package.json
+++ b/test/node/cjs/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "commonjs",
+    "dependencies": {
+        "@elysiajs/stream": "../../.."
+    }
+}

--- a/test/node/esm/index.js
+++ b/test/node/esm/index.js
@@ -1,0 +1,11 @@
+if ("Bun" in globalThis) {
+  throw new Error("❌ Use Node.js to run this test!");
+}
+
+import { Stream } from "@elysiajs/stream";
+
+if (typeof Stream !== "function" && Stream["name"] === "Stream") {
+  throw new Error("❌ ESM Node.js failed");
+}
+
+console.log("✅ ESM Node.js works!");

--- a/test/node/esm/package.json
+++ b/test/node/esm/package.json
@@ -1,0 +1,6 @@
+{
+    "type": "module",
+    "dependencies": {
+        "@elysiajs/stream": "../../.."
+    }
+}


### PR DESCRIPTION
Should fix: https://github.com/elysiajs/stream/issues/5

- Fixed `exports` in `package.json` as mentioned in https://github.com/elysiajs/elysia/issues/50
- Added tests for `CJS` & `ESM` under `Node.js`

---

However `nanoid` doesn't support `CJS` since version `4` (see https://github.com/ai/nanoid/issues/365). There is a fix for this problem, but I don't think it's worth downgrading the version to `3` (see https://github.com/ai/nanoid/issues/365#issuecomment-1188919317).

Therefore this plugin only works with `ESM`.